### PR TITLE
Update OS detection in src/yugabyte-bash-common.sh

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,8 @@ jobs:
                 test/test.sh
               "
           elif [[ $OSTYPE == darwin* ]]; then
+            brew bundle # This should pull in the correct bash version
+            export PATH="/usr/local/bin:${PATH}"
             system_profiler SPSoftwareDataType
             sw_vers
             test/test.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
                 test/test.sh
               "
           elif [[ $OSTYPE == darwin* ]]; then
-            brew bundle # This should pull in the correct bash version
+            bundle install bash # This should pull in the correct bash version
             export PATH="/usr/local/bin:${PATH}"
             system_profiler SPSoftwareDataType
             sw_vers

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
                 test/test.sh
               "
           elif [[ $OSTYPE == darwin* ]]; then
-            bundle install bash # This should pull in the correct bash version
+            brew install bash # This should pull in the correct bash version
             export PATH="/usr/local/bin:${PATH}"
             system_profiler SPSoftwareDataType
             sw_vers

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,1 @@
+brew "bash"

--- a/Brewfile
+++ b/Brewfile
@@ -1,1 +1,0 @@
-brew "bash"

--- a/src/yugabyte-bash-common.sh
+++ b/src/yugabyte-bash-common.sh
@@ -22,6 +22,10 @@ if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
   exit 1
 fi
 
+# Allow the user of the library to decide if warnings should be fatal
+# We default to false meaning we don't fail on a warning.
+FAIL_ON_WARNING=${FAIL_ON_WARNING:-false}
+
 # shellcheck disable=SC2034
 readonly YB_BASH_COMMON_ROOT=$( cd "${BASH_SOURCE/*}" && cd .. && pwd )
 
@@ -328,8 +332,10 @@ warn() {
 
   # shellcheck disable=SC2048,SC2086
   echo -e "[$( get_timestamp )" \
-       "${BASH_SOURCE[$stack_idx1]##*/}:${BASH_LINENO[$stack_idx0]}" \
-       "${FUNCNAME[$stack_idx1]}]" ${RED_COLOR} $* ${NO_COLOR} >&2
+    "${BASH_SOURCE[$stack_idx1]##*/}:${BASH_LINENO[$stack_idx0]}" \
+    "${FUNCNAME[$stack_idx1]}]" $* >&2
+
+  ${FAIL_ON_WARNING} && exit 1
 }
 
 log_file_existence() {

--- a/src/yugabyte-bash-common.sh
+++ b/src/yugabyte-bash-common.sh
@@ -53,6 +53,39 @@ yb_os_detected=false
 # directories that contain a requirements.txt file by the yb_activate_virtualenv function.
 yb_virtualenv_basename=venv
 
+
+# TODO: Remove this method from setup_workstation.sh
+# -------------------------------------------------------------------------------------------------
+# Bash version validation
+# -------------------------------------------------------------------------------------------------
+
+if [[ "$BASH_VERSION" =~ ^3[.] ]]; then
+  if "$is_mac"; then
+    log "Bash 3 detected, using Homebrew to install Bash 4 or later if not already installed"
+    homebrew_bash_path=/usr/local/bin/bash
+    if [[ ! -f $homebrew_bash_path ]]; then
+      # We can't use "set -x" in a subshell in Bash 3, because the error code is not propagated.
+      ( set -x; brew install bash )
+      if [[ ! -f $homebrew_bash_path ]]; then
+        fatal "File $homebrew_bash_path missing even after 'brew install bash'"
+      fi
+    fi
+    homebrew_bash_version=$(
+      "$homebrew_bash_path" --version | egrep -o 'GNU bash, version [0-9]+' | awk '{print $NF}'
+    )
+    if [[ ! $homebrew_bash_version =~ ^[0-9]+$ ]]; then
+      fatal "Could not determine Bash version for $homebrew_bash_version"
+    fi
+    if [[ $homebrew_bash_version -lt 4 ]]; then
+      fatal "$homebrew_bash_version looks like Bash 3 or older"
+    fi
+    "$homebrew_bash_path" "$0" "$@"
+    exit
+  fi
+  echo "Bash 3 is not supported, and can't install Bash 4 on this platform" >&2
+  exit 1
+fi
+
 # -------------------------------------------------------------------------------------------------
 # Git related
 # -------------------------------------------------------------------------------------------------

--- a/src/yugabyte-bash-common.sh
+++ b/src/yugabyte-bash-common.sh
@@ -71,7 +71,7 @@ if [[ "$BASH_VERSION" =~ ^3[.] ]]; then
       fi
     fi
     homebrew_bash_version=$(
-      "$homebrew_bash_path" --version | egrep -o 'GNU bash, version [0-9]+' | awk '{print $NF}'
+      "$homebrew_bash_path" --version | grep -Eo 'GNU bash, version [0-9]+' | awk '{print $NF}'
     )
     if [[ ! $homebrew_bash_version =~ ^[0-9]+$ ]]; then
       fatal "Could not determine Bash version for $homebrew_bash_version"


### PR DESCRIPTION
Use `nproc` to grab the number of CPUs on Linux.

Use the canonical `/etc/os-release` file to determine the Linux distribution.  Print a warning when unsupported Linux is detected.

Add method for printing warnings (message in red, always prints).